### PR TITLE
Feature - Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+### What is the (feature|problem)?
+
+At a high-level, describe the context behind the pull request. Please reference any relevant tickets, if available.
+
+### What is the solution?
+
+At a high-level, describe the chosen solution. A reviewer can consult commit messages for a description of low-level details.
+
+### What areas of the app does it impact?
+
+Some changes (e.g. refactoring changes) may not have any direct impact to the customer.
+
+### How to test?
+
+Testing instructions for reviewers.
+
+### Other
+
+Anything else worth mentioning.


### PR DESCRIPTION
To encourage project contributors to provide meaningful pull request descriptions, which reduce the reviewer burden.

Following the official GitHub instructions here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository