### PR TITLE
Feature - Implement logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,14 +58,15 @@
         "monolog/monolog": "^3.6"
     },
     "require-dev": {
+        "colinodell/psr-testlogger": "^1.3",
+        "filp/whoops": "^2.15.4",
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-development-mode": "^3.12.0",
         "mezzio/mezzio-tooling": "^2.9",
         "phpunit/phpunit": "^10.5.5",
         "psalm/plugin-phpunit": "^0.18.4",
         "roave/security-advisories": "dev-master",
-        "vimeo/psalm": "^5.18",
-        "filp/whoops": "^2.15.4"
+        "vimeo/psalm": "^5.18"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -50,11 +50,12 @@
         "laminas/laminas-component-installer": "^2.6 || ^3.0",
         "laminas/laminas-config-aggregator": "^1.6",
         "laminas/laminas-diactoros": "^3.0.0",
+        "laminas/laminas-servicemanager": "^3.22",
         "laminas/laminas-stdlib": "^3.6",
         "mezzio/mezzio": "^3.7",
+        "mezzio/mezzio-fastroute": "^3.11.0",
         "mezzio/mezzio-helpers": "^5.7",
-        "laminas/laminas-servicemanager": "^3.22",
-        "mezzio/mezzio-fastroute": "^3.11.0"
+        "monolog/monolog": "^3.6"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40725a25672009a81d11ff61faac6aac",
+    "content-hash": "0ab50e32a2eba4cb4207d7373c2b3638",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1972,6 +1972,85 @@
                 }
             ],
             "time": "2024-04-13T18:00:56+00:00"
+        },
+        {
+            "name": "colinodell/psr-testlogger",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/colinodell/psr-testlogger.git",
+                "reference": "291f5b70ea0d3139787d18f442365a8e2784a462"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/colinodell/psr-testlogger/zipball/291f5b70ea0d3139787d18f442365a8e2784a462",
+                "reference": "291f5b70ea0d3139787d18f442365a8e2784a462",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.9.2",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.30.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ColinODell\\PsrTestLogger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "PSR-3 compliant test logger based on psr/log v1's, but compatible with v2 and v3 too!",
+            "homepage": "https://github.com/colinodell/psr-testlogger",
+            "keywords": [
+                "log",
+                "logger",
+                "logging",
+                "mock",
+                "phpunit",
+                "psr",
+                "test",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/colinodell/psr-testlogger/issues",
+                "rss": "https://github.com/colinodell/psr-testlogger/releases.atom",
+                "source": "https://github.com/colinodell/psr-testlogger"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-29T23:03:34+00:00"
         },
         {
             "name": "composer/pcre",

--- a/composer.lock
+++ b/composer.lock
@@ -3916,12 +3916,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "255803f702f07bee1a4edb0b079348c198603514"
+                "reference": "8583ee6fe6fdd08d3dbf9c273fa41704c3a919c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/255803f702f07bee1a4edb0b079348c198603514",
-                "reference": "255803f702f07bee1a4edb0b079348c198603514",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/8583ee6fe6fdd08d3dbf9c273fa41704c3a919c1",
+                "reference": "8583ee6fe6fdd08d3dbf9c273fa41704c3a919c1",
                 "shasum": ""
             },
             "conflict": {
@@ -4475,7 +4475,7 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "ssddanbrown/bookstack": "<22.02.3",
-                "statamic/cms": "<4.46",
+                "statamic/cms": "<4.46|>=5.3,<5.6.2",
                 "stormpath/sdk": "<9.9.99",
                 "studio-42/elfinder": "<2.1.62",
                 "subhh/libconnect": "<7.0.8|>=8,<8.1",
@@ -4622,7 +4622,7 @@
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
                 "yiisoft/yii": "<1.1.29",
-                "yiisoft/yii2": "<2.0.38",
+                "yiisoft/yii2": "<2.0.50",
                 "yiisoft/yii2-authclient": "<2.2.15",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
                 "yiisoft/yii2-dev": "<2.0.43",
@@ -4707,7 +4707,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-29T19:04:21+00:00"
+            "time": "2024-06-03T21:04:39+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5836,16 +5836,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a170e64ae10d00ba89e2acbb590dc2e54da8ad8f"
+                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a170e64ae10d00ba89e2acbb590dc2e54da8ad8f",
-                "reference": "a170e64ae10d00ba89e2acbb590dc2e54da8ad8f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/be5854cee0e8c7b110f00d695d11debdfa1a2a91",
+                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91",
                 "shasum": ""
             },
             "require": {
@@ -5910,7 +5910,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.7"
+                "source": "https://github.com/symfony/console/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -5926,7 +5926,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5997,16 +5997,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d84384f3f67de3cb650db64d685d70395dacfc3f"
+                "reference": "8d7507f02b06e06815e56bb39aa0128e3806208b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d84384f3f67de3cb650db64d685d70395dacfc3f",
-                "reference": "d84384f3f67de3cb650db64d685d70395dacfc3f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8d7507f02b06e06815e56bb39aa0128e3806208b",
+                "reference": "8d7507f02b06e06815e56bb39aa0128e3806208b",
                 "shasum": ""
             },
             "require": {
@@ -6057,7 +6057,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.7"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -6073,7 +6073,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -6153,23 +6153,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "78dde75f8f6dbbca4ec436a4b0087f7af02076d4"
+                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/78dde75f8f6dbbca4ec436a4b0087f7af02076d4",
-                "reference": "78dde75f8f6dbbca4ec436a4b0087f7af02076d4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/4d37529150e7081c51b3c5d5718c55a04a9503f3",
+                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8",
-                "symfony/process": "^5.4|^6.4"
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^5.4|^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -6197,7 +6199,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.7"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -6213,7 +6215,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6615,16 +6617,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "cdb1c81c145fd5aa9b0038bab694035020943381"
+                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/cdb1c81c145fd5aa9b0038bab694035020943381",
-                "reference": "cdb1c81c145fd5aa9b0038bab694035020943381",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8d92dd79149f29e89ee0f480254db595f6a6a2c5",
+                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5",
                 "shasum": ""
             },
             "require": {
@@ -6656,7 +6658,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.7"
+                "source": "https://github.com/symfony/process/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -6672,7 +6674,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6759,16 +6761,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ffeb9591c61f65a68d47f77d12b83fa530227a69"
+                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ffeb9591c61f65a68d47f77d12b83fa530227a69",
-                "reference": "ffeb9591c61f65a68d47f77d12b83fa530227a69",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a147c0f826c4a1f3afb763ab8e009e37c877a44d",
+                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d",
                 "shasum": ""
             },
             "require": {
@@ -6825,7 +6827,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.7"
+                "source": "https://github.com/symfony/string/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -6841,7 +6843,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd2d209ff337587d515517e139e0388f",
+    "content-hash": "40725a25672009a81d11ff61faac6aac",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1169,6 +1169,107 @@
             "time": "2024-01-08T15:20:45+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "4b18b21a5527a3d5ffdac2fd35d3ab25a9597654"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/4b18b21a5527a3d5ffdac2fd35d3ab25a9597654",
+                "reference": "4b18b21a5527a3d5ffdac2fd35d3ab25a9597654",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.5.17",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-12T21:02:21+00:00"
+        },
+        {
             "name": "nikic/fast-route",
             "version": "v1.3.0",
             "source": {
@@ -1542,6 +1643,56 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
             },
             "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "webimpress/safe-writer",
@@ -3679,56 +3830,6 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
-            },
-            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/src/App/src/ConfigProvider.php
+++ b/src/App/src/ConfigProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App;
 
 use App\Factory\LoggerFactory;
+use App\Initializer\LoggerAwareInitializer;
 use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 use Psr\Log\LoggerInterface;
 
@@ -35,13 +36,16 @@ class ConfigProvider
     public function getDependencies(): array
     {
         return [
-            'invokables' => [
+            'invokables'   => [
                 // list here
             ],
-            'factories'  => [
+            'factories'    => [
                 Handler\PingHandler::class     => ReflectionBasedAbstractFactory::class,
                 Handler\HomePageHandler::class => Handler\HomePageHandlerFactory::class,
                 LoggerInterface::class         => LoggerFactory::class,
+            ],
+            'initializers' => [
+                LoggerAwareInitializer::class,
             ],
         ];
     }

--- a/src/App/src/ConfigProvider.php
+++ b/src/App/src/ConfigProvider.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App;
 
+use App\Factory\LoggerFactory;
+use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
+use Psr\Log\LoggerInterface;
+
 /**
  * The configuration provider for the App module
  *
@@ -32,10 +36,12 @@ class ConfigProvider
     {
         return [
             'invokables' => [
-                Handler\PingHandler::class => Handler\PingHandler::class,
+                // list here
             ],
             'factories'  => [
+                Handler\PingHandler::class     => ReflectionBasedAbstractFactory::class,
                 Handler\HomePageHandler::class => Handler\HomePageHandlerFactory::class,
+                LoggerInterface::class         => LoggerFactory::class,
             ],
         ];
     }

--- a/src/App/src/Factory/LoggerFactory.php
+++ b/src/App/src/Factory/LoggerFactory.php
@@ -22,6 +22,7 @@ class LoggerFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $logger = new Logger('default');
+        // TODO - configure stream handler for centralised logging in distributed system
         $logger->pushHandler(
             new StreamHandler(sprintf(self::STREAM_PATH, (new DateTimeImmutable())->format('Ymd')))
         );

--- a/src/App/src/Factory/LoggerFactory.php
+++ b/src/App/src/Factory/LoggerFactory.php
@@ -4,20 +4,27 @@ declare(strict_types=1);
 
 namespace App\Factory;
 
+use DateTimeImmutable;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Container\ContainerInterface;
 
+use function sprintf;
+
 class LoggerFactory implements FactoryInterface
 {
+    private const STREAM_PATH = 'data/log/%s.log';
+
     /**
      * @inheritDoc
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $logger = new Logger('name');
-        $logger->pushHandler(new StreamHandler('data/log/test.log'));
+        $logger = new Logger('default');
+        $logger->pushHandler(
+            new StreamHandler(sprintf(self::STREAM_PATH, (new DateTimeImmutable())->format('Ymd')))
+        );
         return $logger;
     }
 }

--- a/src/App/src/Factory/LoggerFactory.php
+++ b/src/App/src/Factory/LoggerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Container\ContainerInterface;
+
+class LoggerFactory implements FactoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    {
+        $logger = new Logger('name');
+        $logger->pushHandler(new StreamHandler('data/log/test.log'));
+        return $logger;
+    }
+}

--- a/src/App/src/Handler/PingHandler.php
+++ b/src/App/src/Handler/PingHandler.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Handler;
 
 use Laminas\Diactoros\Response\JsonResponse;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -15,6 +18,14 @@ class PingHandler implements RequestHandlerInterface
 {
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        // create a log channel
+        $log = new Logger('name');
+        $log->pushHandler(new StreamHandler('data/log/test.log', Level::Warning));
+
+        // add records to the log
+        $log->warning('Foo');
+        $log->error('Bar');
+
         return new JsonResponse(['ack' => time()]);
     }
 }

--- a/src/App/src/Handler/PingHandler.php
+++ b/src/App/src/Handler/PingHandler.php
@@ -5,26 +5,24 @@ declare(strict_types=1);
 namespace App\Handler;
 
 use Laminas\Diactoros\Response\JsonResponse;
-use Monolog\Handler\StreamHandler;
-use Monolog\Level;
-use Monolog\Logger;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
 
 use function time;
 
 class PingHandler implements RequestHandlerInterface
 {
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        // create a log channel
-        $log = new Logger('name');
-        $log->pushHandler(new StreamHandler('data/log/test.log', Level::Warning));
-
         // add records to the log
-        $log->warning('Foo');
-        $log->error('Bar');
+        $this->logger->warning('Foo');
+        $this->logger->error('Bar');
 
         return new JsonResponse(['ack' => time()]);
     }

--- a/src/App/src/Handler/PingHandler.php
+++ b/src/App/src/Handler/PingHandler.php
@@ -8,15 +8,14 @@ use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 
 use function time;
 
-class PingHandler implements RequestHandlerInterface
+class PingHandler implements RequestHandlerInterface, LoggerAwareInterface
 {
-    public function __construct(private readonly LoggerInterface $logger)
-    {
-    }
+    use LoggerAwareTrait;
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {

--- a/src/App/src/Handler/PingHandler.php
+++ b/src/App/src/Handler/PingHandler.php
@@ -19,10 +19,7 @@ class PingHandler implements RequestHandlerInterface, LoggerAwareInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        // add records to the log
-        $this->logger->warning('Foo');
-        $this->logger->error('Bar');
-
+        $this->logger->info('Ping handler invoked');
         return new JsonResponse(['ack' => time()]);
     }
 }

--- a/src/App/src/Initializer/LoggerAwareInitializer.php
+++ b/src/App/src/Initializer/LoggerAwareInitializer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Initializer;
+
+use Laminas\ServiceManager\Initializer\InitializerInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+class LoggerAwareInitializer implements InitializerInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(ContainerInterface $container, $instance)
+    {
+        if ($instance instanceof LoggerAwareInterface) {
+            /** @var LoggerInterface $logger */
+            $logger = $container->get(LoggerInterface::class);
+            $instance->setLogger($logger);
+        }
+    }
+}

--- a/test/AppTest/Factory/LoggerFactoryTest.php
+++ b/test/AppTest/Factory/LoggerFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Factory;
+
+use App\Factory\LoggerFactory;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class LoggerFactoryTest extends TestCase
+{
+    private function sut(): LoggerInterface // subject under test
+    {
+        return (new LoggerFactory())(new ServiceManager(), LoggerInterface::class);
+    }
+
+    public function testWhenLoggerBuiltThenLoggerNameIsDefault(): void
+    {
+        self::assertEquals('default', $this->sut()->getName());
+    }
+
+    public function testWhenLoggerBuiltThenLoggerHasAtLeastOneHandler(): void
+    {
+        self::assertGreaterThan(0, $this->sut()->getHandlers());
+    }
+}

--- a/test/AppTest/Handler/PingHandlerTest.php
+++ b/test/AppTest/Handler/PingHandlerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace AppTest\Handler;
 
 use App\Handler\PingHandler;
+use ColinODell\PsrTestLogger\TestLogger;
 use Laminas\Diactoros\Response\JsonResponse;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 use function json_decode;
@@ -16,16 +18,33 @@ use const JSON_THROW_ON_ERROR;
 
 class PingHandlerTest extends TestCase
 {
-    public function testResponse(): void
+    private TestLogger $logger;
+
+    protected function setUp(): void
     {
-        $pingHandler = new PingHandler();
-        $response    = $pingHandler->handle(
-            $this->createMock(ServerRequestInterface::class)
-        );
+        $this->logger = new TestLogger();
+    }
+
+    private function sut(): ResponseInterface
+    {
+        $handler = new PingHandler();
+        $handler->setLogger($this->logger);
+        return $handler->handle($this->createMock(ServerRequestInterface::class));
+    }
+
+    public function testWhenPingHandlerInvokedThenJsonResponseReturned(): void
+    {
+        $response = $this->sut();
 
         $json = json_decode((string) $response->getBody(), null, 512, JSON_THROW_ON_ERROR);
 
         self::assertInstanceOf(JsonResponse::class, $response);
         self::assertTrue(property_exists($json, 'ack') && $json->ack !== null);
+    }
+
+    public function testWhenPingHandlerInvokedThenInfoMessageLogged(): void
+    {
+        $this->sut();
+        self::assertTrue($this->logger->hasInfo('Ping handler invoked'));
     }
 }

--- a/test/AppTest/Initializer/LoggerAwareInitializerTest.php
+++ b/test/AppTest/Initializer/LoggerAwareInitializerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Initializer;
+
+use App\Initializer\LoggerAwareInitializer;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+class LoggerAwareInitializerTest extends TestCase
+{
+    public function testWhenInitializedObjectIsLoggerAwareThenLoggerInjectedAsDependency(): void
+    {
+        $container = new ServiceManager();
+        $container->setService(LoggerInterface::class, $this->createMock(LoggerInterface::class));
+
+        $instance = $this->createMock(LoggerAwareInterface::class);
+        $instance->expects($this->once())->method('setLogger');
+
+        (new LoggerAwareInitializer())->__invoke($container, $instance);
+    }
+
+    public function testWhenInitializedObjectIsNotLoggerAwareThenLoggerNotInjectedAsDependency(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->never())->method('get');
+
+        (new LoggerAwareInitializer())->__invoke($container, new class {
+        });
+    }
+}

--- a/test/AppTest/Initializer/LoggerAwareInitializerTest.php
+++ b/test/AppTest/Initializer/LoggerAwareInitializerTest.php
@@ -21,7 +21,7 @@ class LoggerAwareInitializerTest extends TestCase
         $instance = $this->createMock(LoggerAwareInterface::class);
         $instance->expects($this->once())->method('setLogger');
 
-        (new LoggerAwareInitializer())->__invoke($container, $instance);
+        (new LoggerAwareInitializer())($container, $instance);
     }
 
     public function testWhenInitializedObjectIsNotLoggerAwareThenLoggerNotInjectedAsDependency(): void
@@ -29,7 +29,7 @@ class LoggerAwareInitializerTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->never())->method('get');
 
-        (new LoggerAwareInitializer())->__invoke($container, new class {
+        (new LoggerAwareInitializer())($container, new class {
         });
     }
 }


### PR DESCRIPTION
### What is the (feature|problem)?

Relates to: [AS AN application I WANT TO keep a log SO THAT log data can be analysed](https://github.com/ajbleakley/register-app/issues/9)

### What is the solution?

Install [PHP Monolog](https://github.com/Seldaek/monolog), a feature-rich and [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logging library.

Setup logging, within the application, so that services can easily use it by implementing the [LoggerAwareInterface](https://github.com/php-fig/log/blob/master/src/LoggerAwareInterface.php).

An example of how to use has been added to the ping handler (please see testing instructions below).

### What areas of the app does it impact?

The application can now keep a record of logs.

Note - this implementation is fine for now, but it doesn't lend itself to a distributed system. I've added a todo comment to resolved this in the future. Please see [this commit](https://github.com/ajbleakley/register-app/commit/027c9e8274d21395924944e7448087687b37a1c3) for more info.

### How to test?

For now you can spin up the application using PHP's built-in web server:
1. Clone repository.
2. Run `composer install`
3. Run `composer run --timeout=0 serve` to serve the application.
4. Visit http://0.0.0.0:8080/api/ping in your web browser and verify that a log has been recorded in `data/log` directory.