### PR TITLE
Feature - Install Xdebug in PHP-FPM Docker container

### DIFF
--- a/phpdocker/README.md
+++ b/phpdocker/README.md
@@ -30,8 +30,8 @@ add your own hostname on your `/etc/hosts`
 
 Service|Address outside containers
 -------|--------------------------
-Webserver|[localhost:15000](http://localhost:15000)
-MySQL|**host:** `localhost`; **port:** `15002`
+Webserver|[localhost:37000](http://localhost:37000)
+MySQL|**host:** `localhost`; **port:** `37002`
 
 ## Hosts within your environment ##
 
@@ -56,9 +56,9 @@ Memcached|memcached|11211 (default)
   all containers in `SERVICE_NAME`.
 * Execute command inside of container: `docker-compose exec SERVICE_NAME COMMAND` where `COMMAND` is whatever you want
   to run. Examples:
-    * Shell into the PHP container, `docker-compose exec php-fpm bash`
-    * Run symfony console, `docker-compose exec php-fpm bin/console`
-    * Open a mysql shell, `docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD`
+  * Shell into the PHP container, `docker-compose exec php-fpm bash`
+  * Run symfony console, `docker-compose exec php-fpm bin/console`
+  * Open a mysql shell, `docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD`
 
 # Application file permissions #
 

--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -1,11 +1,12 @@
 FROM phpdockerio/php:8.3-fpm
 WORKDIR "/application"
 
+# TODO - segment Dockerfiles for different environments. E.g. xdebug not required on production
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-        git \ 
         php8.3-memcached \ 
         php8.3-mysql \
+        php8.3-xdebug \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 

--- a/phpdocker/php-fpm/php-ini-overrides.ini
+++ b/phpdocker/php-fpm/php-ini-overrides.ini
@@ -1,2 +1,5 @@
 upload_max_filesize = 100M
 post_max_size = 108M
+xdebug.mode = debug
+xdebug.client_host = host.docker.internal
+xdebug.start_with_request = yes


### PR DESCRIPTION
### What is the (feature|problem)?

Relates to: [AS A software engineer I WANT TO use a debugging tool SO THAT I can easily debug the application](https://github.com/ajbleakley/register-app/issues/4)

### What is the solution?

Install and use [Xdebug](https://xdebug.org/) - PHP extension which provides debugging and profiling capabilities.

Use [PHPDocker.io](https://phpdocker.io/) to easily add Xdebug support to our PHP-FPM Dockerfile and documentation.

### What areas of the app does it impact?

No impact to the app. Big impact to software engineers as they can easily debug the application.

### How to test?

1. Clone repository and checkout to this feature branch.
2. Run `docker compose up --build -d` to rebuild your application images and spin up your containers.
3. Run `docker exec -it register-app-php-fpm-1 php -v` and verify that Xdebug is installed with the PHP version running in your container.

> Note - you can easily configure PHPStorm (probably other IDEs too) to use your PHP-FPM Docker container as your IDE CLI Interpreter, so that you have easy access to using Xdebug in your ID: [Configure remote PHP interpreters](https://www.jetbrains.com/help/phpstorm/configuring-remote-interpreters.html).