### PR TITLE
Feature - Add API endpoint to create users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Register App
+# Register App (Unreleased - WIP)
 
 ## Introduction
 Howdy! This portfolio project is part of a [wider project](https://github.com/users/ajbleakley/projects/1) to build a simple, distributed system with user account management and authentication features.
@@ -13,21 +13,24 @@ For more information about the project, please refer to the [full project descri
 
 To run the project locally, you will need to have Docker installed on your host machine. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
+[Postman](https://www.postman.com/) API platform is useful too, because you can download and import [this Postman collection](docs/postman_collection.json) to start exploring the API.
+
 ## Getting Started
 
-Running the application environment locally is simple:
+To build and serve the application environment, simply run:
+```
+docker compose up --build -d
+```
 
-1. Run `docker compose up -d` to build and serve the application environment.
-2. Visit http://localhost:8000/api/ping in your web browser to verify the application is running.
-
-> Note - I will add to this getting started guide as I continue building out the application. Next step is to expose API endpoint for API client to register a user.
+Then, verify the application is running: http://localhost:8000/api/ping
 
 ## Progress Summary
 
 - [Introduce and plan project](https://github.com/users/ajbleakley/projects/1) ✅ (Please click the "Project Details" icon (top-right of project view))
 - [Design API documentation](docs/openapi.yaml) ✅ (WIP - copy/paste the source code into [this online editor](https://editor.swagger.io/) to view)
 - Setup project environment on Docker ✅ (WIP - currently a solid starting point)
-- Implement API design (TODO)
+- Add API endpoint to create a user  ✅ (Working example available in [Postman collection](docs/postman_collection.json))
+- Implement rest of [API design](docs/openapi.yaml) (TODO)
 - End-to-end testing (TODO)
 - API client application (TODO)
 

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "laminas/laminas-diactoros": "^3.0.0",
         "laminas/laminas-servicemanager": "^3.22",
         "laminas/laminas-stdlib": "^3.6",
+        "laminas/laminas-validator": "^2.54",
         "mezzio/mezzio": "^3.7",
         "mezzio/mezzio-fastroute": "^3.11.0",
         "mezzio/mezzio-helpers": "^5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29ccf217dbc51462170b994ded173db2",
+    "content-hash": "3ffbe5cdfef6831f1d3055a8c61916f3",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1516,6 +1516,90 @@
                 }
             ],
             "time": "2023-10-31T16:26:05+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "2.54.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "43b84efd642d55188dc0a8ffee4de187c1dc2314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/43b84efd642d55188dc0a8ffee4de187c1dc2314",
+                "reference": "43b84efd642d55188dc0a8ffee4de187c1dc2314",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.13",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
+            },
+            "conflict": {
+                "zendframework/zend-validator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^2.5",
+                "laminas/laminas-db": "^2.20",
+                "laminas/laminas-filter": "^2.35.2",
+                "laminas/laminas-i18n": "^2.26.0",
+                "laminas/laminas-session": "^2.20",
+                "laminas/laminas-uri": "^2.11.0",
+                "phpunit/phpunit": "^10.5.20",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-factory": "^1.1.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "suggest": {
+                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
+                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
+                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-validator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-validator/issues",
+                "rss": "https://github.com/laminas/laminas-validator/releases.atom",
+                "source": "https://github.com/laminas/laminas-validator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-05-16T12:03:20+00:00"
         },
         {
             "name": "mezzio/mezzio",

--- a/config/config.php
+++ b/config/config.php
@@ -14,6 +14,7 @@ $cacheConfig = [
 ];
 
 $aggregator = new ConfigAggregator([
+    \Laminas\Validator\ConfigProvider::class,
     \Mezzio\Tooling\ConfigProvider::class,
     \Mezzio\Helper\ConfigProvider::class,
     \Mezzio\Router\FastRouteRouter\ConfigProvider::class,

--- a/config/routes.php
+++ b/config/routes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\ADR\Action\API\CreateUserAction;
 use Mezzio\Application;
+use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
 use Mezzio\MiddlewareFactory;
 use Psr\Container\ContainerInterface;
 
@@ -45,5 +46,8 @@ return static function (Application $app, MiddlewareFactory $factory, ContainerI
     $app->get('/api/ping', App\Handler\PingHandler::class, 'api.ping');
 
     // users resource
-    $app->post(sprintf(API_PATH_TEMPLATE, 'users'), CreateUserAction::class, 'api.users.create');
+    $app->post(sprintf(API_PATH_TEMPLATE, 'users'), [
+        BodyParamsMiddleware::class,
+        CreateUserAction::class,
+    ], 'api.users.create');
 };

--- a/config/routes.php
+++ b/config/routes.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\ADR\Action\API\CreateUserAction;
 use Mezzio\Application;
 use Mezzio\MiddlewareFactory;
 use Psr\Container\ContainerInterface;
@@ -37,7 +38,12 @@ use Psr\Container\ContainerInterface;
  * );
  */
 
+const API_PATH_TEMPLATE = '/api/v1/%s';
+
 return static function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
     $app->get('/', App\Handler\HomePageHandler::class, 'home');
     $app->get('/api/ping', App\Handler\PingHandler::class, 'api.ping');
+
+    // users resource
+    $app->post(sprintf(API_PATH_TEMPLATE, 'users'), CreateUserAction::class, 'api.users.create');
 };

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,0 +1,202 @@
+{
+	"info": {
+		"_postman_id": "59edefe2-424c-4712-a4dd-8bf13bb64b03",
+		"name": "Register App - API",
+		"description": "# 🚀 Get started here\n\nThis template guides you through CRUD operations (GET, POST, PUT, DELETE), variables, and tests.\n\n## 🔖 **How to use this template**\n\n#### **Step 1: Send requests**\n\nRESTful APIs allow you to perform CRUD operations using the POST, GET, PUT, and DELETE HTTP methods.\n\nThis collection contains each of these [request](https://learning.postman.com/docs/sending-requests/requests/) types. Open each request and click \"Send\" to see what happens.\n\n#### **Step 2: View responses**\n\nObserve the response tab for status code (200 OK), response time, and size.\n\n#### **Step 3: Send new Body data**\n\nUpdate or add new data in \"Body\" in the POST request. Typically, Body data is also used in PUT request.\n\n```\n{\n    \"name\": \"Add your name in the body\"\n}\n\n ```\n\n#### **Step 4: Update the variable**\n\nVariables enable you to store and reuse values in Postman. We have created a [variable](https://learning.postman.com/docs/sending-requests/variables/) called `base_url` with the sample request [https://postman-api-learner.glitch.me](https://postman-api-learner.glitch.me). Replace it with your API endpoint to customize this collection.\n\n#### **Step 5: Add tests in the \"Scripts\" tab**\n\nAdding tests to your requests can help you confirm that your API is working as expected. You can write test scripts in JavaScript and view the output in the \"Test Results\" tab.\n\n<img src=\"https://content.pstmn.io/fa30ea0a-373d-4545-a668-e7b283cca343/aW1hZ2UucG5n\" alt=\"\" height=\"1530\" width=\"2162\">\n\n## 💪 Pro tips\n\n- Use folders to group related requests and organize the collection.\n    \n- Add more [scripts](https://learning.postman.com/docs/writing-scripts/intro-to-scripts/) to verify if the API works as expected and execute workflows.\n    \n\n## 💡Related templates\n\n[API testing basics](https://go.postman.co/redirect/workspace?type=personal&collectionTemplateId=e9a37a28-055b-49cd-8c7e-97494a21eb54&sourceTemplateId=ddb19591-3097-41cf-82af-c84273e56719)  \n[API documentation](https://go.postman.co/redirect/workspace?type=personal&collectionTemplateId=e9c28f47-1253-44af-a2f3-20dce4da1f18&sourceTemplateId=ddb19591-3097-41cf-82af-c84273e56719)  \n[Authorization methods](https://go.postman.co/redirect/workspace?type=personal&collectionTemplateId=31a9a6ed-4cdf-4ced-984c-d12c9aec1c27&sourceTemplateId=ddb19591-3097-41cf-82af-c84273e56719)",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "35175148"
+	},
+	"item": [
+		{
+			"name": "Get user (not implemented yet)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/users/{{identifier}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"users",
+						"{{identifier}}"
+					]
+				},
+				"description": "This is a GET request and it is used to \"get\" data from an endpoint. There is no request body for a GET request, but you can use query parameters to help specify the resource you want data on (e.g., in this request, we have `id=1`).\n\nA successful GET response will have a `200 OK` status, and should include some kind of response body - for example, HTML web content or JSON data."
+			},
+			"response": []
+		},
+		{
+			"name": "Create user",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+							"});",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"email\": \"example@email.com\",\n    \"password\": \"lowerUPPER123@$!\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{base_url}}/users",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"users"
+					]
+				},
+				"description": "This is a POST request, submitting data to an API via the request body. This request submits JSON data, and the data is reflected in the response.\n\nA successful POST request typically returns a `200 OK` or `201 Created` response code."
+			},
+			"response": []
+		},
+		{
+			"name": "Update user (not implemented yet)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful PUT request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 201, 204]);",
+							"});",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"name\": \"Add your name in the body\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{base_url}}/users/{{identifier}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"users",
+						"{{identifier}}"
+					]
+				},
+				"description": "This is a PUT request and it is used to overwrite an existing piece of data. For instance, after you create an entity with a POST request, you may want to modify that later. You can do that using a PUT request. You typically identify the entity being updated by including an identifier in the URL (eg. `id=1`).\n\nA successful PUT request typically returns a `200 OK`, `201 Created`, or `204 No Content` response code."
+			},
+			"response": []
+		},
+		{
+			"name": "Delete user (not implemented yet)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful DELETE request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 202, 204]);",
+							"});",
+							""
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{base_url}}/users/{{identifier}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"users",
+						"{{identifier}}"
+					]
+				},
+				"description": "This is a DELETE request, and it is used to delete data that was previously created via a POST request. You typically identify the entity being updated by including an identifier in the URL (eg. `id=1`).\n\nA successful DELETE request typically returns a `200 OK`, `202 Accepted`, or `204 No Content` response code."
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "identifier",
+			"value": ""
+		},
+		{
+			"key": "base_url",
+			"value": "http://localhost:8000/api/v1"
+		}
+	]
+}

--- a/src/App/src/ADR/Action/API/CreateUserAction.php
+++ b/src/App/src/ADR/Action/API/CreateUserAction.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Action\API;
+
+use App\ADR\Domain\CreateUser\CreateUserDomain;
+use App\ADR\Domain\CreateUser\CreateUserDomainRequest;
+use App\ADR\Domain\CreateUser\NotReadyToCreateUserDomainResult;
+use App\ADR\Domain\CreateUser\UserCreatedDomainResult;
+use App\ADR\Responder\API\JsonResponder;
+use App\ADR\Responder\API\JsonResponderRequest;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function filter_var;
+use function htmlspecialchars;
+
+use const FILTER_SANITIZE_EMAIL;
+
+class CreateUserAction implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly CreateUserDomain $createUserDomain,
+        private readonly JsonResponder $jsonResponder
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        // sanitise user input (note - validation is performed by the domain request)
+        $email    = filter_var($request->getParsedBody()['email'] ?? '', FILTER_SANITIZE_EMAIL);
+        $password = htmlspecialchars($request->getParsedBody()['password'] ?? '');
+
+        // domain
+        try {
+            $domainRequest = new CreateUserDomainRequest($email, $password);
+            $domainResult  = $this->createUserDomain->process($domainRequest);
+        } catch (InvalidArgumentException $exception) {
+            $domainResult = new NotReadyToCreateUserDomainResult($exception->getMessage());
+        }
+
+        // responder
+        if (! $domainResult instanceof UserCreatedDomainResult) {
+            // TODO - use [mezzio-problem-details](https://docs.mezzio.dev/mezzio-problem-details/)
+            return $this->jsonResponder->respond(
+                new JsonResponderRequest(['message' => $domainResult->getMessage()], 400)
+            );
+        }
+
+        // TODO - improve structure of API response (maybe use existing PHP library)
+        $responderRequest = new JsonResponderRequest([
+            'message' => 'User created successfully',
+            'email'   => $domainResult->getUser()->getEmail(),
+        ], 200);
+
+        return $this->jsonResponder->respond($responderRequest);
+    }
+}

--- a/src/App/src/ADR/Action/API/CreateUserAction.php
+++ b/src/App/src/ADR/Action/API/CreateUserAction.php
@@ -8,9 +8,9 @@ use App\ADR\Domain\CreateUser\CreateUserDomain;
 use App\ADR\Domain\CreateUser\CreateUserDomainRequest;
 use App\ADR\Domain\CreateUser\NotReadyToCreateUserDomainResult;
 use App\ADR\Domain\CreateUser\UserCreatedDomainResult;
+use App\ADR\Domain\InvalidDomainRequestException;
 use App\ADR\Responder\API\JsonResponder;
 use App\ADR\Responder\API\JsonResponderRequest;
-use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -41,7 +41,7 @@ class CreateUserAction implements RequestHandlerInterface
         try {
             $domainRequest = new CreateUserDomainRequest($email, $password);
             $domainResult  = $this->createUserDomain->process($domainRequest);
-        } catch (InvalidArgumentException $exception) {
+        } catch (InvalidDomainRequestException $exception) {
             $domainResult = new NotReadyToCreateUserDomainResult($exception->getMessage());
         }
 

--- a/src/App/src/ADR/Domain/CreateUser/CreateUserDomain.php
+++ b/src/App/src/ADR/Domain/CreateUser/CreateUserDomain.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain\CreateUser;
+
+use App\ADR\Domain\DomainInterface;
+use App\ADR\Domain\DomainRequestInterface;
+use App\ADR\Domain\DomainResultInterface;
+use App\Entity\UserEntity;
+use Doctrine\ORM\EntityManagerInterface;
+use Throwable;
+
+use function password_hash;
+
+use const PASSWORD_DEFAULT;
+
+class CreateUserDomain implements DomainInterface
+{
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+    }
+
+    /**
+     * @param CreateUserDomainRequest $request
+     */
+    public function process(DomainRequestInterface $request): DomainResultInterface
+    {
+        // TODO - deal with a rich user model here, rather than anaemic user entity (DTO)
+        $user = (new UserEntity())
+            ->setEmail($request->getEmail())
+            ->setPasswordHash(password_hash($request->getPassword(), PASSWORD_DEFAULT));
+
+        // TODO - decouple domain from Doctrine entity manager
+        try {
+            $this->entityManager->persist($user);
+        } catch (Throwable $exception) {
+            return new UserNotCreatedDomainResult($exception->getMessage());
+        }
+
+        // TODO - dispatch user created event
+
+        return new UserCreatedDomainResult($user);
+    }
+}

--- a/src/App/src/ADR/Domain/CreateUser/CreateUserDomainRequest.php
+++ b/src/App/src/ADR/Domain/CreateUser/CreateUserDomainRequest.php
@@ -5,17 +5,13 @@ declare(strict_types=1);
 namespace App\ADR\Domain\CreateUser;
 
 use App\ADR\Domain\DomainRequestInterface;
-use InvalidArgumentException;
+use App\ADR\Domain\InvalidDomainRequestException;
 use Laminas\Validator\EmailAddress;
 use Laminas\Validator\Regex;
-
-use function sprintf;
 
 class CreateUserDomainRequest implements DomainRequestInterface
 {
     private const REQUIRED_FIELDS = ['email', 'password'];
-
-    private const EXCEPTION_MESSAGE_TEMPLATE = 'Please provide a valid %s';
 
     /*
      * Password regex - at least 1 upper case letter, 1 lower case letter, 1 number, and 1 special character
@@ -42,13 +38,19 @@ class CreateUserDomainRequest implements DomainRequestInterface
      */
     public function validate(): void
     {
+        $validationMessages = [];
+
         if (! (new EmailAddress())->isValid($this->email)) {
-            throw new InvalidArgumentException(sprintf(self::EXCEPTION_MESSAGE_TEMPLATE, $this->email));
+            $validationMessages[] = 'Please provide a valid email';
         }
 
         // Could use https://docs.laminas.dev/laminas-validator/validators/undisclosed-password/
         if (! (new Regex(self::PASSWORD_REGEX))->isValid($this->password)) {
-            throw new InvalidArgumentException(sprintf(self::EXCEPTION_MESSAGE_TEMPLATE, $this->password));
+            $validationMessages[] = 'Please provide a secure password';
+        }
+
+        if (! empty($validationMessages)) {
+            throw new InvalidDomainRequestException($validationMessages);
         }
     }
 }

--- a/src/App/src/ADR/Domain/CreateUser/CreateUserDomainRequest.php
+++ b/src/App/src/ADR/Domain/CreateUser/CreateUserDomainRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain\CreateUser;
+
+use App\ADR\Domain\DomainRequestInterface;
+use InvalidArgumentException;
+use Laminas\Validator\EmailAddress;
+use Laminas\Validator\Regex;
+
+use function sprintf;
+
+class CreateUserDomainRequest implements DomainRequestInterface
+{
+    private const REQUIRED_FIELDS = ['email', 'password'];
+
+    private const EXCEPTION_MESSAGE_TEMPLATE = 'Please provide a valid %s';
+
+    /*
+     * Password regex - at least 1 upper case letter, 1 lower case letter, 1 number, and 1 special character
+     */
+    private const PASSWORD_REGEX = '/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/';
+
+    public function __construct(private readonly string $email, private readonly string $password)
+    {
+        $this->validate();
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate(): void
+    {
+        if (! (new EmailAddress())->isValid($this->email)) {
+            throw new InvalidArgumentException(sprintf(self::EXCEPTION_MESSAGE_TEMPLATE, $this->email));
+        }
+
+        // Could use [Undisclosed Password Validator](https://docs.laminas.dev/laminas-validator/validators/undisclosed-password/)
+        if (! (new Regex(self::PASSWORD_REGEX))->isValid($this->password)) {
+            throw new InvalidArgumentException(sprintf(self::EXCEPTION_MESSAGE_TEMPLATE, $this->password));
+        }
+    }
+}

--- a/src/App/src/ADR/Domain/CreateUser/CreateUserDomainRequest.php
+++ b/src/App/src/ADR/Domain/CreateUser/CreateUserDomainRequest.php
@@ -46,7 +46,7 @@ class CreateUserDomainRequest implements DomainRequestInterface
             throw new InvalidArgumentException(sprintf(self::EXCEPTION_MESSAGE_TEMPLATE, $this->email));
         }
 
-        // Could use [Undisclosed Password Validator](https://docs.laminas.dev/laminas-validator/validators/undisclosed-password/)
+        // Could use https://docs.laminas.dev/laminas-validator/validators/undisclosed-password/
         if (! (new Regex(self::PASSWORD_REGEX))->isValid($this->password)) {
             throw new InvalidArgumentException(sprintf(self::EXCEPTION_MESSAGE_TEMPLATE, $this->password));
         }

--- a/src/App/src/ADR/Domain/CreateUser/NotReadyToCreateUserDomainResult.php
+++ b/src/App/src/ADR/Domain/CreateUser/NotReadyToCreateUserDomainResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain\CreateUser;
+
+use App\ADR\Domain\DomainResultInterface;
+
+class NotReadyToCreateUserDomainResult implements DomainResultInterface
+{
+    public function __construct(private readonly string $message)
+    {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/App/src/ADR/Domain/CreateUser/UserCreatedDomainResult.php
+++ b/src/App/src/ADR/Domain/CreateUser/UserCreatedDomainResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain\CreateUser;
+
+use App\ADR\Domain\DomainResultInterface;
+use App\Entity\UserEntity;
+
+class UserCreatedDomainResult implements DomainResultInterface
+{
+    public function __construct(private readonly UserEntity $user)
+    {
+    }
+
+    public function getUser(): UserEntity
+    {
+        return $this->user;
+    }
+}

--- a/src/App/src/ADR/Domain/CreateUser/UserNotCreatedDomainResult.php
+++ b/src/App/src/ADR/Domain/CreateUser/UserNotCreatedDomainResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain\CreateUser;
+
+use App\ADR\Domain\DomainResultInterface;
+
+class UserNotCreatedDomainResult implements DomainResultInterface
+{
+    public function __construct(private readonly string $message)
+    {
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/App/src/ADR/Domain/DomainInterface.php
+++ b/src/App/src/ADR/Domain/DomainInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain;
+
+interface DomainInterface
+{
+    public function process(DomainRequestInterface $request): DomainResultInterface;
+}

--- a/src/App/src/ADR/Domain/DomainRequestInterface.php
+++ b/src/App/src/ADR/Domain/DomainRequestInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain;
+
+use InvalidArgumentException;
+
+interface DomainRequestInterface
+{
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function validate(): void;
+}

--- a/src/App/src/ADR/Domain/DomainRequestInterface.php
+++ b/src/App/src/ADR/Domain/DomainRequestInterface.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace App\ADR\Domain;
 
-use InvalidArgumentException;
-
 interface DomainRequestInterface
 {
     /**
-     * @throws InvalidArgumentException
+     * @throws InvalidDomainRequestException
      */
     public function validate(): void;
 }

--- a/src/App/src/ADR/Domain/DomainResultInterface.php
+++ b/src/App/src/ADR/Domain/DomainResultInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain;
+
+interface DomainResultInterface
+{
+}

--- a/src/App/src/ADR/Domain/InvalidDomainRequestException.php
+++ b/src/App/src/ADR/Domain/InvalidDomainRequestException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Domain;
+
+use InvalidArgumentException;
+
+use function implode;
+use function strtolower;
+use function ucfirst;
+
+class InvalidDomainRequestException extends InvalidArgumentException
+{
+    public function __construct(array $messages)
+    {
+        parent::__construct(ucfirst(strtolower(implode(', ', $messages))));
+    }
+}

--- a/src/App/src/ADR/Responder/API/JsonResponder.php
+++ b/src/App/src/ADR/Responder/API/JsonResponder.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Responder\API;
+
+use App\ADR\Responder\ResponderInterface;
+use App\ADR\Responder\ResponderRequestInterface;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+
+class JsonResponder implements ResponderInterface
+{
+    /**
+     * @param JsonResponderRequest $request
+     */
+    public function respond(ResponderRequestInterface $request): ResponseInterface
+    {
+        return new JsonResponse($request->getData(), $request->getStatus());
+    }
+}

--- a/src/App/src/ADR/Responder/API/JsonResponderRequest.php
+++ b/src/App/src/ADR/Responder/API/JsonResponderRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Responder\API;
+
+use App\ADR\Responder\ResponderRequestInterface;
+
+class JsonResponderRequest implements ResponderRequestInterface
+{
+    public function __construct(private readonly array $data, private readonly int $status = 200)
+    {
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+}

--- a/src/App/src/ADR/Responder/ResponderInterface.php
+++ b/src/App/src/ADR/Responder/ResponderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Responder;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface ResponderInterface
+{
+    public function respond(ResponderRequestInterface $request): ResponseInterface;
+}

--- a/src/App/src/ADR/Responder/ResponderRequestInterface.php
+++ b/src/App/src/ADR/Responder/ResponderRequestInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ADR\Responder;
+
+interface ResponderRequestInterface
+{
+}

--- a/src/App/src/ConfigProvider.php
+++ b/src/App/src/ConfigProvider.php
@@ -38,16 +38,18 @@ class ConfigProvider
     public function getDependencies(): array
     {
         return [
-            'invokables'   => [
+            'invokables'         => [
                 // list here
             ],
-            'factories'    => [
-                Handler\PingHandler::class     => ReflectionBasedAbstractFactory::class,
+            'abstract_factories' => [
+                ReflectionBasedAbstractFactory::class,
+            ],
+            'factories'          => [
                 Handler\HomePageHandler::class => Handler\HomePageHandlerFactory::class,
                 LoggerInterface::class         => LoggerFactory::class,
                 EntityManagerInterface::class  => EntityManagerFactory::class,
             ],
-            'initializers' => [
+            'initializers'       => [
                 LoggerAwareInitializer::class,
             ],
         ];

--- a/test/AppTest/ADR/Action/API/CreateUserActionTest.php
+++ b/test/AppTest/ADR/Action/API/CreateUserActionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\ADR\Action\API;
+
+use App\ADR\Action\API\CreateUserAction;
+use App\ADR\Domain\CreateUser\CreateUserDomain;
+use App\ADR\Domain\CreateUser\UserCreatedDomainResult;
+use App\ADR\Domain\CreateUser\UserNotCreatedDomainResult;
+use App\ADR\Responder\API\JsonResponder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CreateUserActionTest extends TestCase
+{
+    // dependencies
+    private CreateUserDomain $domain;
+    private JsonResponder $responder;
+
+    // parameters
+    private ServerRequestInterface $request;
+
+    protected function setUp(): void
+    {
+        // dependencies
+        $this->domain    = $this->createMock(CreateUserDomain::class);
+        $this->responder = new JsonResponder();
+
+        // parameters
+        $this->request = $this->createMock(ServerRequestInterface::class);
+    }
+
+    private function sut(): ResponseInterface // subject under test
+    {
+        return (new CreateUserAction($this->domain, $this->responder))->handle($this->request);
+    }
+
+    public function testWhenUserCreatedThenRespondWithSuccessResponse(): void
+    {
+        // given
+        $this->request->method('getParsedBody')->willReturn([
+            'email'    => 'example@email.com',
+            'password' => 'lowerUPPER123@$!',
+        ]);
+        $this->domain->method('process')
+            ->willReturn($this->createMock(UserCreatedDomainResult::class));
+
+        // when
+        $response = $this->sut();
+
+        // then
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testWhenNotReadyToCreateUserThenRespondWithFailureResponse(): void
+    {
+        // given
+        $this->request->method('getParsedBody')->willReturn([
+            // missing required body
+        ]);
+
+        // when
+        $response = $this->sut();
+
+        // then
+        self::assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testWhenUserCreationFailsThenRespondWithFailureResponse(): void
+    {
+        // given
+        $this->domain->method('process')
+            ->willReturn($this->createMock(UserNotCreatedDomainResult::class));
+
+        // when
+        $response = $this->sut();
+
+        // then
+        self::assertEquals(400, $response->getStatusCode());
+    }
+}

--- a/test/AppTest/ADR/Domain/CreateUser/CreateUserDomainRequestTest.php
+++ b/test/AppTest/ADR/Domain/CreateUser/CreateUserDomainRequestTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\ADR\Domain\CreateUser;
+
+use App\ADR\Domain\CreateUser\CreateUserDomainRequest;
+use Exception;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class CreateUserDomainRequestTest extends TestCase
+{
+    public function testWhenValidFieldsProvidedThenDomainRequestIsValid(): void
+    {
+        // Password validation - require at least 1 capital letter, 1 number, 1 special character, at least 8 characters
+        try {
+            new CreateUserDomainRequest('example@email.com', 'lowerUPPER123@$!');
+            $this->assertTrue(true);
+        } catch (Exception $exception) {
+            $this->fail('Exception should not be thrown when valid fields provided');
+        }
+    }
+
+    public function testWhenInvalidEmailProvidedThenDomainRequestIsInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new CreateUserDomainRequest('invalid_email.com', 'weak_password');
+    }
+
+    public static function invalidPasswordProvider(): array
+    {
+        return [
+            'empty'      => [''],
+            'no lower'   => ['UPPER123@$!'],
+            'no upper'   => ['lower123@$!'],
+            'no number'  => ['lowerUPPER@$!'],
+            'no special' => ['lowerUPPER123'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidPasswordProvider
+     */
+    public function testWhenInvalidPasswordProvidedThenDomainRequestIsInvalid(string $password): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new CreateUserDomainRequest('invalid_email.com', $password);
+    }
+}

--- a/test/AppTest/ADR/Domain/CreateUser/CreateUserDomainTest.php
+++ b/test/AppTest/ADR/Domain/CreateUser/CreateUserDomainTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\ADR\Domain\CreateUser;
+
+use App\ADR\Domain\CreateUser\CreateUserDomain;
+use App\ADR\Domain\CreateUser\CreateUserDomainRequest;
+use App\ADR\Domain\CreateUser\UserCreatedDomainResult;
+use App\ADR\Domain\CreateUser\UserNotCreatedDomainResult;
+use App\ADR\Domain\DomainResultInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class CreateUserDomainTest extends TestCase
+{
+    // dependencies
+    private EntityManagerInterface $entityManager;
+
+    // parameters
+    private CreateUserDomainRequest $domainRequest;
+
+    protected function setUp(): void
+    {
+        // dependencies
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        // parameters
+        $this->domainRequest = $this->createMock(CreateUserDomainRequest::class);
+    }
+
+    private function sut(): DomainResultInterface
+    {
+        return (new CreateUserDomain($this->entityManager))->process($this->domainRequest);
+    }
+
+    public function testWhenUserIsCreatedThenUserEntityIsPersisted(): void
+    {
+        // expect
+        $this->entityManager->expects($this->once())->method('persist');
+
+        // when
+        $this->sut();
+    }
+
+    public function testWhenPersistenceFailsThenDomainSignalsUserNotCreated(): void
+    {
+        // given
+        $this->entityManager->method('persist')
+            ->willThrowException($this->createMock(Throwable::class));
+
+        // when
+        $result = $this->sut();
+
+        // then
+        self::assertInstanceOf(UserNotCreatedDomainResult::class, $result);
+    }
+
+    public function testWhenPersistenceSucceedsThenDomainSignalsUserCreated(): void
+    {
+        // when
+        $result = $this->sut();
+
+        // then
+        self::assertInstanceOf(UserCreatedDomainResult::class, $result);
+    }
+}


### PR DESCRIPTION
### What is the (feature|problem)?

Relates to: [AS AN application I WANT TO accept POST requests SO THAT API clients can register users](https://github.com/ajbleakley/register-app/issues/14)

### What is the solution?

Please refer to [my proposal](https://github.com/ajbleakley/register-app/issues/14). There was quite a lot to do and I should really have broken this feature down into smaller pull requests so that it's easier to review. However, all changes should be clearly explained in the commit messages so please read through the commits chronologically.

Worth noting that this is not a perfect implementation. There are many comments that I will revisit in follow-up tasks but I want to get a minimum viable feature in place.

Also I spent some time considering whether the responsibility of hashing password should reside with the API client or API server. From [reading online](https://stackoverflow.com/questions/3391242), one side of the argument is that passwords should never be transmitted in plain text (which was my original presumption), the other side of the argument is that using HTTPS and hashing the password before storing into the server database are enough for most of the cases. I.e. if you don't trust HTTPS there are bigger problems to consider.

I don't plan to release this application because it's a portfolio project to demonstrate my current capabilities, therefore to keep things simple I will place the responsibility of hashing the password on the API server and assume that if the application were to be released it would use HTTPS.

### What areas of the app does it impact?

Adds API endpoint for API clients to create application users.

### How to test?
1. Rebuild your application images and spin up your containers:
```
docker compose up --build -d
```
2. Download and import [the Postman collection](docs/postman_collection.json) to test the new API endpoint.
