### PR TITLE
Feature - Add API endpoint to delete user

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -56,10 +56,10 @@ return static function (Application $app, MiddlewareFactory $factory, ContainerI
         CreateUserAction::class,
     ]);
 
-    $app->patch('/api/v1/users/{identifier}', [
+    $app->route('/api/v1/users/{identifier}', [
         BodyParamsMiddleware::class,
         ModifyUserAction::class,
-    ]);
+    ], ['PATCH', 'DELETE']);
 
     // API docs
     $app->get('/api/v1/doc/invalid-parameter', App\Doc\InvalidParameterHandler::class);

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -253,7 +253,7 @@
 			"response": []
 		},
 		{
-			"name": "Delete user (not implemented yet)",
+			"name": "Delete user",
 			"event": [
 				{
 					"listen": "test",

--- a/src/App/src/Service/UserService.php
+++ b/src/App/src/Service/UserService.php
@@ -40,6 +40,12 @@ class UserService
         $this->entityManager->flush();
     }
 
+    public function removeUser(UserInterface $user): void
+    {
+        $this->entityManager->remove($user);
+        $this->entityManager->flush();
+    }
+
     public function isEmailAlreadyRegistered(string $email): bool
     {
         return (bool) $this->entityManager->createQueryBuilder()

--- a/src/App/src/Trait/FetchUserTrait.php
+++ b/src/App/src/Trait/FetchUserTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trait;
+
+use App\Entity\User\UserInterface;
+use App\Exception\NoResourceFoundException;
+use App\Service\UserService;
+use Exception;
+use Psr\Http\Message\ServerRequestInterface;
+
+use function htmlspecialchars;
+
+trait FetchUserTrait
+{
+    private readonly UserService $users;
+
+    public function fetchUser(ServerRequestInterface $request): UserInterface
+    {
+        $identifier = htmlspecialchars($request->getAttribute('identifier'));
+
+        try {
+            return $this->users->fetchByIdentifier($identifier);
+        } catch (Exception $exception) {
+            throw NoResourceFoundException::create($exception->getMessage());
+        }
+    }
+}

--- a/test/AppTest/Trait/FetchUserTraitTest.php
+++ b/test/AppTest/Trait/FetchUserTraitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Trait;
+
+use App\Entity\User\UserInterface;
+use App\Exception\NoResourceFoundException;
+use App\Service\UserService;
+use App\Trait\FetchUserTrait;
+use Doctrine\ORM\NoResultException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchUserTraitTest extends TestCase
+{
+    // dependencies
+    private UserService $users;
+
+    // parameters
+    private ServerRequestInterface $request;
+
+    public function setUp(): void
+    {
+        // dependencies
+        $this->users = $this->createMock(UserService::class);
+
+        // parameters
+        $this->request = $this->createMock(ServerRequestInterface::class);
+        $this->request->method('getAttribute')->willReturn('identifier');
+    }
+
+    private function sut(): UserInterface
+    {
+        return (new class ($this->users)
+        {
+            use FetchUserTrait;
+
+            public function __construct(UserService $users)
+            {
+                $this->users = $users;
+            }
+        })->fetchUser($this->request);
+    }
+
+    public function testWhenUserNotFetchedThenExitsEarly(): void
+    {
+        // given
+        $this->users->method('fetchByIdentifier')
+            ->willThrowException(new NoResultException());
+
+        // expect
+        $this->expectException(NoResourceFoundException::class);
+
+        // when
+        $this->sut();
+    }
+
+    public function testWhenUserFetchedThenUserReturned(): void
+    {
+        // given
+        $user = $this->createMock(UserInterface::class);
+        $this->users->method('fetchByIdentifier')
+            ->willReturn($user);
+
+        // when
+        $result = $this->sut();
+
+        // then
+        self::assertEquals($user, $result);
+    }
+}


### PR DESCRIPTION
### What is the (feature|problem)?

Relates to: [AS AN application I WANT TO accept DELETE requests SO THAT API clients can delete users](https://github.com/ajbleakley/register-app/issues/27)

### What is the solution?

In my proposal I opted for hard delete to keep things simple for now. In the future, to comply with GDPR could implement a soft delete for 14 days and then follow this up with a hard delete. This would give a user a notice period, just incase they wish to cancel their account deletion request.

### What areas of the app does it impact?

Adds API endpoint for API client to (hard) delete application user.

### How to test?
1. Rebuild your application images and spin up your containers:
```
docker compose up --build -d
```
2. Download and import [the Postman collection](docs/postman_collection.json) to test the new API endpoint.