### PR TITLE
Feature - Use Doctrine custom mapping type for emails

### DIFF
--- a/src/App/src/Entity/User/Email.php
+++ b/src/App/src/Entity/User/Email.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\User;
+
+use InvalidArgumentException;
+
+use function filter_var;
+
+use const FILTER_VALIDATE_EMAIL;
+
+class Email
+{
+    private string $email;
+
+    public function __construct(string $email)
+    {
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidArgumentException('Invalid email format');
+        }
+
+        $this->email = $email;
+    }
+
+    public function __toString(): string
+    {
+        return $this->email;
+    }
+}

--- a/src/App/src/Entity/User/EmailType.php
+++ b/src/App/src/Entity/User/EmailType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\User;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Exception\InvalidType;
+use Doctrine\DBAL\Types\StringType;
+
+use function is_string;
+
+class EmailType extends StringType
+{
+    public const EMAIL = 'email';
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof Email) {
+            return (string) $value;
+        }
+
+        throw InvalidType::new(
+            $value,
+            static::class,
+            ['null', Email::class],
+        );
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?Email
+    {
+        if ($value === null || $value instanceof Email) {
+            return $value;
+        }
+
+        if (! is_string($value)) {
+            throw InvalidType::new(
+                $value,
+                static::class,
+                ['null', 'string']
+            );
+        }
+
+        return new Email($value);
+    }
+
+    public function getName(): string
+    {
+        return self::EMAIL;
+    }
+}

--- a/src/App/src/Entity/User/User.php
+++ b/src/App/src/Entity/User/User.php
@@ -7,7 +7,6 @@ namespace App\Entity\User;
 use App\Helper\PasswordValidationHelper;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
-use Laminas\Validator\EmailAddress;
 use OutOfBoundsException;
 use Ramsey\Uuid\Uuid;
 
@@ -43,23 +42,16 @@ class User implements UserInterface
     #[ORM\Column(name: 'password_hash', type: 'string')]
     protected string $passwordHash;
 
-    #[ORM\Column(type: 'string')]
-    private string $email;
+    #[ORM\Column(type: 'email')]
+    private Email $email;
 
     public function __construct(string $email, string $password)
     {
         $this->identifier = Uuid::uuid1()->toString();
         $this->createdAt  = $this->updatedAt = new DateTimeImmutable();
-        $this->username   = $this->email = $email; // On user creation, email used as username
+        $this->username   = $email;
+        $this->email      = new Email($email);
         $this->updatePassword($password);
-        $this->validate();
-    }
-
-    private function validate(): void
-    {
-        if (! (new EmailAddress())->isValid($this->email)) {
-            throw new OutOfBoundsException('Invalid email');
-        }
     }
 
     public function identifier(): string
@@ -88,9 +80,9 @@ class User implements UserInterface
         return $this->username;
     }
 
-    public function email(): string
+    public function email(): Email
     {
-        return $this->username;
+        return $this->email;
     }
 
     public function updatePassword(string $password): self

--- a/src/App/src/Entity/User/UserHydrator.php
+++ b/src/App/src/Entity/User/UserHydrator.php
@@ -21,7 +21,7 @@ class UserHydrator implements HydratorInterface
             'identifier' => $object->identifier(),
             'created_at' => $object->createdAt()->format('c'),
             'updated_at' => $object->updatedAt()->format('c'),
-            'email'      => $object->email(),
+            'email'      => (string) $object->email(),
         ];
     }
 

--- a/src/App/src/Entity/User/UserInterface.php
+++ b/src/App/src/Entity/User/UserInterface.php
@@ -18,7 +18,7 @@ interface UserInterface
 
     public function username(): string;
 
-    public function email(): string;
+    public function email(): Email;
 
     public function updatePassword(string $password): self;
 

--- a/src/App/src/Factory/EntityManagerFactory.php
+++ b/src/App/src/Factory/EntityManagerFactory.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Factory;
 
+use App\Entity\User\EmailType;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -15,9 +18,14 @@ class EntityManagerFactory implements FactoryInterface
     /**
      * @inheritDoc
      * @return EntityManager
+     * @throws Exception
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
+        if (! Type::hasType('email')) {
+            Type::addType('email', EmailType::class);
+        }
+
         // Create a simple "default" Doctrine ORM configuration for Attributes
         $config = ORMSetup::createAttributeMetadataConfiguration(
             paths: [__DIR__ . '/../Entity'],

--- a/test/AppTest/Entity/User/EmailTest.php
+++ b/test/AppTest/Entity/User/EmailTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Entity\User;
+
+use App\Entity\User\Email;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class EmailTest extends TestCase
+{
+    public function testWhenInvalidEmailThenObjectNotInstantiated(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Email('invalid_email.com');
+    }
+
+    public function testWhenValidEmailThenObjectInstantiated(): void
+    {
+        $this->expectNotToPerformAssertions();
+        new Email('valid@email.com');
+    }
+}

--- a/test/AppTest/Service/UserServiceTest.php
+++ b/test/AppTest/Service/UserServiceTest.php
@@ -64,12 +64,12 @@ class UserServiceTest extends TestCase
 
     public function testWhenUserDoesNotAlreadyExistForEmail(): void
     {
-        self::assertFalse($this->sut()->isEmailAlreadyRegistered($this->dummyUser->email()));
+        self::assertFalse($this->sut()->isEmailAlreadyRegistered((string) $this->dummyUser->email()));
     }
 
     public function testWhenUserAlreadyExistForEmail(): void
     {
         $this->sut()->saveUser($this->dummyUser);
-        self::assertTrue($this->sut()->isEmailAlreadyRegistered($this->dummyUser->email()));
+        self::assertTrue($this->sut()->isEmailAlreadyRegistered((string) $this->dummyUser->email()));
     }
 }


### PR DESCRIPTION
### What is the (feature|problem)?

Refactor - decouple email validation logic from the user entity. Why? In the future, this logic may be handy for other use cases, e.g. validating a user's recovery email account(s).

Note - I'm aware this could be seen as over engineering at this stage, because currently this email validation is only required in one place. However, it feels like the right thing to do and it helps build a richer domain model for the user entity.

### What is the solution?

Introduce an email object (capable of validating itself) and register a custom mapping type in Doctrine to marshal this object in/out of the database.

### What areas of the app does it impact?

No impact - refactoring only.

### How to test?

Rebuild and spin up the application to test everything is still working:
```
docker compose up --build -d
```