### PR TITLE
Feature - Immutable and updatable entity abstracts/interfaces

### DIFF
--- a/src/App/src/Entity/AbstractImmutableEntity.php
+++ b/src/App/src/Entity/AbstractImmutableEntity.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+
+abstract class AbstractImmutableEntity implements ImmutableEntityInterface
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    protected int|null $id;
+
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'guid')]
+    protected string|null $identifier;
+
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'created_at', type: 'datetime_immutable')]
+    protected DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->identifier = Uuid::uuid1()->toString();
+        $this->createdAt  = new DateTimeImmutable();
+    }
+
+    public function identifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function createdAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/App/src/Entity/AbstractUpdatableEntity.php
+++ b/src/App/src/Entity/AbstractUpdatableEntity.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+
+abstract class AbstractUpdatableEntity extends AbstractImmutableEntity implements UpdatableEntityInterface
+{
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'updated_at', type: 'datetime_immutable')]
+    protected DateTimeImmutable $updatedAt;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setUpdatedAt();
+    }
+
+    public function updatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * Gets triggered every time on update
+     *
+     * @ORM\PreUpdate
+     */
+    public function setUpdatedAt(): self
+    {
+        $this->updatedAt = new DateTimeImmutable();
+        return $this;
+    }
+}

--- a/src/App/src/Entity/ImmutableEntityInterface.php
+++ b/src/App/src/Entity/ImmutableEntityInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use DateTimeImmutable;
+
+interface ImmutableEntityInterface
+{
+    public function identifier(): string;
+
+    public function createdAt(): DateTimeImmutable;
+}

--- a/src/App/src/Entity/UpdatableEntityInterface.php
+++ b/src/App/src/Entity/UpdatableEntityInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use DateTimeImmutable;
+
+interface UpdatableEntityInterface extends ImmutableEntityInterface
+{
+    public function updatedAt(): DateTimeImmutable;
+
+    public function setUpdatedAt(): self;
+}

--- a/src/App/src/Entity/User/User.php
+++ b/src/App/src/Entity/User/User.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace App\Entity\User;
 
+use App\Entity\AbstractUpdatableEntity;
 use App\Helper\PasswordValidationHelper;
-use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use OutOfBoundsException;
-use Ramsey\Uuid\Uuid;
 
 use function password_hash;
 use function password_verify;
@@ -17,25 +16,8 @@ use const PASSWORD_DEFAULT;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'users')]
-class User implements UserInterface
+class User extends AbstractUpdatableEntity implements UserInterface
 {
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private int|null $id;
-
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'guid')]
-    private string|null $identifier;
-
-    #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'created_at', type: 'datetime_immutable')]
-    private DateTimeImmutable $createdAt;
-
-    #[ORM\GeneratedValue]
-    #[ORM\Column(name: 'updated_at', type: 'datetime_immutable')]
-    private DateTimeImmutable $updatedAt;
-
     #[ORM\Column(type: 'string')]
     private string $username;
 
@@ -47,42 +29,15 @@ class User implements UserInterface
 
     public function __construct(string $email, string $password)
     {
-        $this->identifier = Uuid::uuid1()->toString();
-        $this->createdAt  = $this->updatedAt = new DateTimeImmutable();
-        $this->username   = $email;
-        $this->email      = new Email($email);
+        parent::__construct();
+        $this->username = $email;
+        $this->email    = new Email($email);
         $this->updatePassword($password);
-    }
-
-    public function identifier(): string
-    {
-        return $this->identifier;
-    }
-
-    public function createdAt(): DateTimeImmutable
-    {
-        return $this->createdAt;
-    }
-
-    public function updatedAt(): DateTimeImmutable
-    {
-        return $this->updatedAt;
-    }
-
-    public function setUpdatedAt(): self
-    {
-        $this->updatedAt = new DateTimeImmutable();
-        return $this;
     }
 
     public function username(): string
     {
         return $this->username;
-    }
-
-    public function email(): Email
-    {
-        return $this->email;
     }
 
     public function updatePassword(string $password): self
@@ -98,5 +53,10 @@ class User implements UserInterface
     public function verifyPassword(string $password): bool
     {
         return password_verify($password, $this->passwordHash);
+    }
+
+    public function email(): Email
+    {
+        return $this->email;
     }
 }

--- a/src/App/src/Entity/User/UserInterface.php
+++ b/src/App/src/Entity/User/UserInterface.php
@@ -4,18 +4,10 @@ declare(strict_types=1);
 
 namespace App\Entity\User;
 
-use DateTimeImmutable;
+use App\Entity\UpdatableEntityInterface;
 
-interface UserInterface
+interface UserInterface extends UpdatableEntityInterface
 {
-    public function identifier(): string;
-
-    public function createdAt(): DateTimeImmutable;
-
-    public function updatedAt(): DateTimeImmutable;
-
-    public function setUpdatedAt(): self;
-
     public function username(): string;
 
     public function email(): Email;


### PR DESCRIPTION
### What is the (feature|problem)?

Refactor - a number of the user entity fields (id, identifier, timestamps, etc.) would lend themselves to other entities too.

Note - I'm aware this could be seen as over engineering at this stage as there is only a single entity (user) in the project. However, it feels like the right thing to do and improves the readability of the user entity by focussing on the domain logic relevant to users. 

### What is the solution?

Define interfaces for immutable and updatable entities, then introduce an abstract implementation for each.

### What areas of the app does it impact?

No impact - refactor only.

### How to test?

Rebuild and spin up the application to test everything is still working:
```
docker compose up --build -d
```